### PR TITLE
Add automation for Ubuntu hardening and DLP-protected LLM gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.venv/
+venv/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,110 @@
-# test
+# LLM Gateway Server Hardening Toolkit
+
+This project provides a set of automation scripts and a reference web service to
+bootstrap a hardened Ubuntu server that terminates HTTPS traffic with an RSA
+certificate and proxies requests to an LLM behind a regex-driven data loss
+prevention (DLP) layer.
+
+## Components
+
+- **scripts/harden_server.sh** – applies security hardening, including kernel
+  tuning, firewalling, Fail2Ban, and unattended upgrades.
+- **scripts/setup_https.sh** – creates an RSA certificate with OpenSSL and
+  configures Nginx for HTTPS offloading.
+- **scripts/deploy_app.sh** – installs the FastAPI-based DLP gateway as a
+  systemd service.
+- **app/** – Python application exposing a `/v1/prompt` endpoint that checks
+  prompts against common sensitive-data patterns before forwarding them to an
+  upstream LLM.
+
+## Prerequisites
+
+- Ubuntu 22.04 LTS (or a compatible Debian-based distribution)
+- Root privileges for running the setup scripts
+- Outbound connectivity to reach your target LLM endpoint (optional)
+
+## Usage
+
+Clone the repository onto the server and run the scripts in order:
+
+```bash
+sudo ./scripts/harden_server.sh
+sudo ./scripts/setup_https.sh example.com
+sudo ./scripts/deploy_app.sh
+```
+
+Replace `example.com` with the hostname you intend to serve. The HTTPS script
+creates the following files under `/etc/ssl/llm-gateway/`:
+
+- `privkey.pem` – 4096-bit RSA private key
+- `fullchain.pem` – self-signed certificate valid for one year
+- `dhparam.pem` – Diffie-Hellman parameters for stronger forward secrecy
+
+The deployment script installs the FastAPI application to `/opt/llm-gateway`
+and registers a systemd service named `llm-gateway.service`. The service listens
+on `127.0.0.1:8000`; the Nginx reverse proxy terminates TLS and forwards traffic
+locally.
+
+## Configuring the DLP Gateway
+
+The application honours several environment variables that can be set in the
+systemd unit file or exported before starting the server:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `LLM_API_ENDPOINT` | *(stubbed responses)* | HTTPS endpoint of the upstream LLM |
+| `LLM_API_KEY` | *(unset)* | API key or bearer token for the LLM |
+| `DLP_POLICY` | `block` | Default enforcement mode (`block` or `mask`) |
+| `DLP_ALLOW_MASKING` | `true` | Whether clients may request masking via the API |
+| `LOG_LEVEL` | `INFO` | Python logging level |
+
+When `LLM_API_ENDPOINT` is not configured, the service returns a stub response
+which is useful for functional testing of the DLP layer.
+
+### API Example
+
+Send a prompt with masking enabled to replace sensitive matches before the
+request is forwarded:
+
+```bash
+curl -k https://example.com/v1/prompt \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt": "Use card 4111 1111 1111 1111 today", "mask": true}'
+```
+
+The response includes the sanitized prompt as well as any DLP detections.
+
+## Security Considerations
+
+- Running `harden_server.sh` will disable password-based SSH authentication and
+  require key-based login. Ensure that you have uploaded SSH keys before
+  executing the script.
+- Review the generated Nginx configuration and adjust the cipher suites to
+  comply with your organisation's policies.
+- Replace the self-signed certificate with one issued by a trusted authority for
+  production use.
+
+## Development and Testing
+
+Create a virtual environment and install the Python dependencies:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r app/requirements.txt pytest
+```
+
+Run the automated tests:
+
+```bash
+pytest
+```
+
+You can start the API locally (without TLS) using uvicorn:
+
+```bash
+uvicorn app.app:app --reload --host 0.0.0.0 --port 8000
+```
+
+The DLP patterns are defined in `app/dlp.py`. Adjust or extend them to match
+sensitive tokens relevant to your environment.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""LLM gateway package."""

--- a/app/app.py
+++ b/app/app.py
@@ -1,0 +1,114 @@
+"""FastAPI application exposing a DLP-protected LLM gateway."""
+
+from __future__ import annotations
+
+import logging
+from typing import List
+
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+
+from .config import Settings, settings
+from .dlp import DLPViolation, DataLossPrevention, Detection
+from .llm_client import LLMClient, LLMRequestError, client as llm_client
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=settings.log_level)
+
+app = FastAPI(
+    title="LLM Gateway with Regex DLP",
+    version="1.0.0",
+    description=(
+        "Proxy requests to an upstream language model while enforcing "
+        "regex-based data loss prevention policies."
+    ),
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=False,
+    allow_methods=["POST", "OPTIONS"],
+    allow_headers=["*"],
+)
+
+
+def get_settings() -> Settings:
+    return settings
+
+
+def get_dlp_engine() -> DataLossPrevention:
+    return DataLossPrevention()
+
+
+def get_llm_client() -> LLMClient:
+    return llm_client
+
+
+class DetectionModel(BaseModel):
+    label: str
+    match: str
+    start: int
+    end: int
+
+    @classmethod
+    def from_detection(cls, detection: Detection) -> "DetectionModel":
+        return cls(**detection.to_dict())
+
+
+class PromptRequest(BaseModel):
+    prompt: str = Field(..., description="Prompt to forward to the LLM")
+    mask: bool = Field(False, description="Mask sensitive matches instead of blocking")
+
+
+class PromptResponse(BaseModel):
+    response: str
+    sanitized_prompt: str
+    policy: str
+    detections: List[DetectionModel] | None
+
+
+@app.get("/healthz", tags=["system"])
+async def health_check() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/v1/prompt", response_model=PromptResponse, tags=["llm"])
+async def forward_prompt(
+    payload: PromptRequest,
+    dlp_engine: DataLossPrevention = Depends(get_dlp_engine),
+    app_settings: Settings = Depends(get_settings),
+    llm: LLMClient = Depends(get_llm_client),
+) -> PromptResponse:
+    policy = "mask" if payload.mask and app_settings.allow_masking_override else app_settings.dlp_policy
+    logger.debug("Applying policy '%s' to prompt", policy)
+
+    try:
+        sanitized_prompt, detections = dlp_engine.enforce(payload.prompt, policy=policy)
+    except DLPViolation as exc:
+        logger.warning("Blocked prompt due to DLP violation: %s", exc.detections)
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "message": "Prompt rejected by DLP policy",
+                "detections": [det.to_dict() for det in exc.detections],
+            },
+        )
+
+    try:
+        llm_response = await llm.complete(sanitized_prompt)
+    except LLMRequestError as exc:
+        logger.error("Upstream LLM request failed: %s", exc)
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    detection_models = [DetectionModel.from_detection(item) for item in detections] if detections else None
+    return PromptResponse(
+        response=llm_response,
+        sanitized_prompt=sanitized_prompt,
+        policy=policy,
+        detections=detection_models,
+    )
+
+
+__all__ = ["app"]

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,45 @@
+"""Application configuration helpers."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+def _to_bool(value: str | None, *, default: bool) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _to_policy(value: str | None, *, default: str) -> str:
+    if not value:
+        return default
+    lowered = value.lower()
+    if lowered not in {"block", "mask"}:
+        return default
+    return lowered
+
+
+@dataclass(slots=True)
+class Settings:
+    """Runtime configuration derived from environment variables."""
+
+    llm_endpoint: str | None
+    llm_api_key: str | None
+    dlp_policy: str
+    allow_masking_override: bool
+    log_level: str
+
+    @classmethod
+    def load(cls) -> "Settings":
+        return cls(
+            llm_endpoint=os.getenv("LLM_API_ENDPOINT"),
+            llm_api_key=os.getenv("LLM_API_KEY"),
+            dlp_policy=_to_policy(os.getenv("DLP_POLICY"), default="block"),
+            allow_masking_override=_to_bool(os.getenv("DLP_ALLOW_MASKING"), default=True),
+            log_level=os.getenv("LOG_LEVEL", "INFO"),
+        )
+
+
+settings = Settings.load()

--- a/app/dlp.py
+++ b/app/dlp.py
@@ -1,0 +1,134 @@
+"""Regex-based data loss prevention helpers."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Callable, Iterable, List, Sequence
+
+
+@dataclass(slots=True, frozen=True)
+class Detection:
+    """A single sensitive match found by the DLP engine."""
+
+    label: str
+    match: str
+    start: int
+    end: int
+
+    def to_dict(self) -> dict[str, str | int]:
+        return {
+            "label": self.label,
+            "match": self.match,
+            "start": self.start,
+            "end": self.end,
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class SensitivePattern:
+    """Definition of a sensitive data detection rule."""
+
+    label: str
+    pattern: re.Pattern[str]
+    description: str
+    validator: Callable[[str], bool] | None = None
+
+
+class DLPViolation(Exception):
+    """Raised when sensitive data is detected and policy forbids it."""
+
+    def __init__(self, detections: Sequence[Detection]):
+        super().__init__("Sensitive content detected")
+        self.detections = list(detections)
+
+
+def _luhn_checksum(candidate: str) -> bool:
+    digits = [int(char) for char in re.sub(r"\D", "", candidate)]
+    if len(digits) < 13 or len(digits) > 19:
+        return False
+    checksum = 0
+    parity = len(digits) % 2
+    for index, digit in enumerate(digits):
+        if index % 2 == parity:
+            digit *= 2
+            if digit > 9:
+                digit -= 9
+        checksum += digit
+    return checksum % 10 == 0
+
+
+def _build_default_patterns() -> List[SensitivePattern]:
+    return [
+        SensitivePattern(
+            label="credit_card",
+            pattern=re.compile(r"\b(?:\d[ -]?){13,19}\b"),
+            description="Potential payment card number",
+            validator=_luhn_checksum,
+        ),
+        SensitivePattern(
+            label="ssn",
+            pattern=re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
+            description="U.S. social security number",
+        ),
+        SensitivePattern(
+            label="api_key",
+            pattern=re.compile(r"(?i)\b(?:sk|api|key)[-_]?[0-9a-z]{16,}\b"),
+            description="Generic API key",
+        ),
+        SensitivePattern(
+            label="aws_access_key",
+            pattern=re.compile(r"AKIA[0-9A-Z]{16}"),
+            description="AWS access key identifier",
+        ),
+        SensitivePattern(
+            label="private_key",
+            pattern=re.compile(r"-----BEGIN (?:RSA|EC|DSA) PRIVATE KEY-----"),
+            description="Private key material",
+        ),
+    ]
+
+
+class DataLossPrevention:
+    """Simple regex-based DLP engine."""
+
+    def __init__(self, patterns: Iterable[SensitivePattern] | None = None, *, mask_char: str = "*") -> None:
+        self._patterns = list(patterns) if patterns is not None else _build_default_patterns()
+        self._mask_char = mask_char
+
+    def scan(self, text: str) -> List[Detection]:
+        matches: List[Detection] = []
+        for rule in self._patterns:
+            for match in rule.pattern.finditer(text):
+                candidate = match.group(0)
+                if rule.validator and not rule.validator(candidate):
+                    continue
+                matches.append(Detection(rule.label, candidate, match.start(), match.end()))
+        return matches
+
+    def mask(self, text: str, detections: Sequence[Detection]) -> str:
+        if not detections:
+            return text
+        masked = list(text)
+        for detection in sorted(detections, key=lambda item: item.start):
+            for index in range(detection.start, detection.end):
+                if 0 <= index < len(masked):
+                    masked[index] = self._mask_char
+        return "".join(masked)
+
+    def enforce(self, text: str, *, policy: str = "block") -> tuple[str, List[Detection]]:
+        detections = self.scan(text)
+        if detections:
+            normalized_policy = policy.lower()
+            if normalized_policy == "block":
+                raise DLPViolation(detections)
+            if normalized_policy == "mask":
+                return self.mask(text, detections), detections
+        return text, detections
+
+
+__all__ = [
+    "DataLossPrevention",
+    "DLPViolation",
+    "Detection",
+]

--- a/app/llm_client.py
+++ b/app/llm_client.py
@@ -1,0 +1,79 @@
+"""Minimal HTTP client used to communicate with an upstream LLM."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from .config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class LLMRequestError(RuntimeError):
+    """Raised when the upstream model cannot be contacted."""
+
+
+class LLMClient:
+    """Async client capable of forwarding prompts to a remote LLM."""
+
+    def __init__(self, endpoint: str | None, api_key: str | None, *, timeout: float = 30.0) -> None:
+        self._endpoint = endpoint
+        self._api_key = api_key
+        self._timeout = timeout
+
+    @classmethod
+    def from_settings(cls) -> "LLMClient":
+        return cls(settings.llm_endpoint, settings.llm_api_key)
+
+    async def complete(self, prompt: str) -> str:
+        """Send the prompt to the configured LLM endpoint.
+
+        If no endpoint is configured, a stub response is returned.  This makes
+        it possible to run the gateway in offline mode for testing.
+        """
+
+        if not self._endpoint:
+            logger.debug("No upstream endpoint configured; returning stub response")
+            return f"[stubbed LLM] {prompt}"
+
+        headers = {"Content-Type": "application/json"}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+
+        payload = {"prompt": prompt}
+
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as client:
+                response = await client.post(self._endpoint, json=payload, headers=headers)
+                response.raise_for_status()
+        except httpx.HTTPError as exc:  # pragma: no cover - network dependent
+            logger.exception("Failed to contact upstream LLM")
+            raise LLMRequestError(str(exc)) from exc
+
+        data = response.json()
+        return self._extract_text(data)
+
+    def _extract_text(self, data: Any) -> str:
+        """Normalize common response shapes into a string."""
+
+        if isinstance(data, dict):
+            if "response" in data:
+                return str(data["response"])
+            if "choices" in data and isinstance(data["choices"], list) and data["choices"]:
+                choice = data["choices"][0]
+                if isinstance(choice, dict):
+                    for key in ("text", "message", "content"):
+                        if key in choice:
+                            value = choice[key]
+                            if isinstance(value, dict) and "content" in value:
+                                return str(value["content"])
+                            return str(value)
+        return str(data)
+
+
+client = LLMClient.from_settings()
+
+__all__ = ["LLMClient", "LLMRequestError", "client"]

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,0 +1,3 @@
+fastapi>=0.110,<0.112
+uvicorn[standard]>=0.22,<0.26
+httpx>=0.25,<0.28

--- a/app/tests/test_dlp.py
+++ b/app/tests/test_dlp.py
@@ -1,0 +1,27 @@
+import pytest
+
+from app.dlp import DLPViolation, DataLossPrevention
+
+
+def test_credit_card_detection_with_luhn_validation() -> None:
+    engine = DataLossPrevention()
+    prompt = "Use card 4111 1111 1111 1111 to buy"
+    detections = engine.scan(prompt)
+    assert any(d.label == "credit_card" for d in detections)
+
+
+def test_masking_replaces_sensitive_tokens() -> None:
+    engine = DataLossPrevention()
+    prompt = "API key sk-testsecretkeyvalue"
+    masked, detections = engine.enforce(prompt, policy="mask")
+    assert masked != prompt
+    assert detections
+    for detection in detections:
+        assert detection.match not in masked
+
+
+def test_block_policy_raises_violation() -> None:
+    engine = DataLossPrevention()
+    prompt = "SSN 123-45-6789 should not pass"
+    with pytest.raises(DLPViolation):
+        engine.enforce(prompt, policy="block")

--- a/config/fail2ban/jail.local
+++ b/config/fail2ban/jail.local
@@ -1,0 +1,11 @@
+[DEFAULT]
+bantime  = 1h
+findtime = 10m
+maxretry = 5
+backend  = systemd
+ignoreip = 127.0.0.1/8
+
+[sshd]
+enabled  = true
+port     = ssh
+logpath  = /var/log/auth.log

--- a/config/nginx/llm_gateway.conf
+++ b/config/nginx/llm_gateway.conf
@@ -1,0 +1,40 @@
+upstream llm_gateway {
+    server 127.0.0.1:8000;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name {{SERVER_NAME}};
+
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name {{SERVER_NAME}};
+
+    ssl_certificate /etc/ssl/llm-gateway/fullchain.pem;
+    ssl_certificate_key /etc/ssl/llm-gateway/privkey.pem;
+    ssl_dhparam /etc/ssl/llm-gateway/dhparam.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers 'ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256';
+    ssl_prefer_server_ciphers on;
+    ssl_session_timeout 5m;
+
+    add_header Content-Security-Policy "default-src 'self'" always;
+    add_header Referrer-Policy "strict-origin" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+
+    location / {
+        proxy_pass http://llm_gateway;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_redirect off;
+    }
+}

--- a/config/systemd/llm-gateway.service
+++ b/config/systemd/llm-gateway.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=LLM Gateway with regex-based DLP
+After=network.target
+
+[Service]
+Type=simple
+User=llm-gateway
+Group=llm-gateway
+WorkingDirectory=/opt/llm-gateway
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/opt/llm-gateway/venv/bin/uvicorn app.app:app --host 127.0.0.1 --port 8000
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,10 @@
+"""Test configuration ensuring the repository root is importable."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/scripts/deploy_app.sh
+++ b/scripts/deploy_app.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deploy the LLM gateway application with regex-based DLP onto the current host.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_USER="llm-gateway"
+APP_DIR="/opt/llm-gateway"
+PY_BIN="python3"
+
+log() {
+  echo "[deploy] $*"
+}
+
+require_root() {
+  if [[ $(id -u) -ne 0 ]]; then
+    echo "This script must be run as root" >&2
+    exit 1
+  fi
+}
+
+create_user() {
+  if id "${APP_USER}" >/dev/null 2>&1; then
+    log "User ${APP_USER} already exists"
+  else
+    log "Creating dedicated system user ${APP_USER}"
+    useradd --system --shell /usr/sbin/nologin --create-home --home-dir "${APP_DIR}" "${APP_USER}"
+  fi
+}
+
+sync_application_code() {
+  log "Syncing application code to ${APP_DIR}"
+  mkdir -p "${APP_DIR}"
+  rm -rf "${APP_DIR}/app"
+  cp -r "${REPO_ROOT}/app" "${APP_DIR}/"
+  install -o "${APP_USER}" -g "${APP_USER}" -m 0700 -d "${APP_DIR}/run"
+  chown -R "${APP_USER}:${APP_USER}" "${APP_DIR}"
+}
+
+setup_virtualenv() {
+  log "Creating Python virtual environment"
+  "${PY_BIN}" -m venv "${APP_DIR}/venv"
+  "${APP_DIR}/venv/bin/pip" install --upgrade pip >/dev/null
+  "${APP_DIR}/venv/bin/pip" install -r "${APP_DIR}/app/requirements.txt" >/dev/null
+  chown -R "${APP_USER}:${APP_USER}" "${APP_DIR}"
+}
+
+configure_systemd() {
+  log "Installing systemd service"
+  install -m 0644 -o root -g root "${REPO_ROOT}/config/systemd/llm-gateway.service" /etc/systemd/system/llm-gateway.service
+  systemctl daemon-reload
+  systemctl enable --now llm-gateway.service
+}
+
+main() {
+  require_root
+  command -v "${PY_BIN}" >/dev/null || { echo "python3 is required" >&2; exit 1; }
+
+  create_user
+  sync_application_code
+  setup_virtualenv
+  configure_systemd
+
+  log "Deployment finished"
+}
+
+main "$@"

--- a/scripts/harden_server.sh
+++ b/scripts/harden_server.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Harden an Ubuntu host with sensible defaults for running the LLM gateway.
+# This script must be executed as root and is designed to be idempotent.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+log() {
+  echo "[harden] $*"
+}
+
+require_root() {
+  if [[ $(id -u) -ne 0 ]]; then
+    echo "This script must be run as root" >&2
+    exit 1
+  fi
+}
+
+enable_unattended_upgrades() {
+  log "Enabling unattended security upgrades"
+  apt-get install -y unattended-upgrades >/dev/null
+  DEBIAN_FRONTEND=noninteractive dpkg-reconfigure --priority=low unattended-upgrades
+}
+
+configure_sysctl() {
+  local sysctl_file="/etc/sysctl.d/99-llm-gateway.conf"
+  log "Applying kernel hardening parameters in ${sysctl_file}"
+  cat >"${sysctl_file}" <<'CFG'
+# Harden network stack
+net.ipv4.ip_forward = 0
+net.ipv4.conf.all.accept_redirects = 0
+net.ipv4.conf.default.accept_redirects = 0
+net.ipv4.conf.all.send_redirects = 0
+net.ipv4.conf.default.send_redirects = 0
+net.ipv4.conf.all.accept_source_route = 0
+net.ipv4.conf.default.accept_source_route = 0
+net.ipv4.conf.all.log_martians = 1
+net.ipv4.conf.default.log_martians = 1
+net.ipv4.tcp_syncookies = 1
+net.ipv4.icmp_echo_ignore_broadcasts = 1
+net.ipv4.icmp_ignore_bogus_error_responses = 1
+kernel.randomize_va_space = 2
+CFG
+  sysctl --system >/dev/null
+}
+
+configure_sshd() {
+  local sshd_config="/etc/ssh/sshd_config"
+  if [[ -f "${sshd_config}" ]]; then
+    log "Hardening SSH daemon configuration"
+    cp "${sshd_config}"{,.bak}
+    sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin prohibit-password/' "${sshd_config}"
+    sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication no/' "${sshd_config}"
+    sed -i 's/^#\?KexAlgorithms.*/KexAlgorithms curve25519-sha256@libssh.org/' "${sshd_config}" || true
+    if ! grep -q '^AllowTcpForwarding no' "${sshd_config}"; then
+      echo 'AllowTcpForwarding no' >> "${sshd_config}"
+    fi
+    systemctl restart sshd
+  else
+    log "sshd_config not found, skipping SSH hardening"
+  fi
+}
+
+configure_ufw() {
+  log "Configuring uncomplicated firewall"
+  ufw --force reset >/dev/null
+  ufw default deny incoming >/dev/null
+  ufw default allow outgoing >/dev/null
+  ufw allow OpenSSH >/dev/null
+  ufw allow 80/tcp >/dev/null
+  ufw allow 443/tcp >/dev/null
+  ufw --force enable >/dev/null
+}
+
+configure_fail2ban() {
+  log "Configuring Fail2Ban"
+  apt-get install -y fail2ban >/dev/null
+  install -m 0644 -o root -g root "${REPO_ROOT}/config/fail2ban/jail.local" /etc/fail2ban/jail.local
+  systemctl enable --now fail2ban
+}
+
+main() {
+  require_root
+
+  log "Updating package cache and upgrading base system"
+  apt-get update >/dev/null
+  DEBIAN_FRONTEND=noninteractive apt-get -y upgrade >/dev/null
+
+  log "Installing base packages"
+  apt-get install -y ufw curl gnupg python3 python3-venv ca-certificates nginx >/dev/null
+
+  configure_sysctl
+  configure_sshd
+  configure_ufw
+  configure_fail2ban
+  enable_unattended_upgrades
+
+  log "System hardening complete"
+}
+
+main "$@"

--- a/scripts/setup_https.sh
+++ b/scripts/setup_https.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate an RSA certificate and configure Nginx for HTTPS termination.
+# Usage: ./scripts/setup_https.sh example.com
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DOMAIN="${1:-llm.local}"
+CERT_DIR="/etc/ssl/llm-gateway"
+
+log() {
+  echo "[https] $*"
+}
+
+require_root() {
+  if [[ $(id -u) -ne 0 ]]; then
+    echo "This script must be run as root" >&2
+    exit 1
+  fi
+}
+
+generate_certificates() {
+  log "Generating RSA certificate for ${DOMAIN}"
+  mkdir -p "${CERT_DIR}"
+  chmod 700 "${CERT_DIR}"
+  openssl req -x509 -nodes -sha256 \
+    -newkey rsa:4096 \
+    -days 365 \
+    -keyout "${CERT_DIR}/privkey.pem" \
+    -out "${CERT_DIR}/fullchain.pem" \
+    -subj "/CN=${DOMAIN}/O=LLM Gateway/OU=Security" >/dev/null 2>&1
+  chmod 600 "${CERT_DIR}/privkey.pem"
+  chown root:root "${CERT_DIR}/privkey.pem" "${CERT_DIR}/fullchain.pem"
+
+  if [[ ! -f "${CERT_DIR}/dhparam.pem" ]]; then
+    log "Generating strong Diffie-Hellman parameters (this may take a while)"
+    openssl dhparam -out "${CERT_DIR}/dhparam.pem" 4096 >/dev/null 2>&1
+  fi
+}
+
+configure_nginx() {
+  local nginx_conf="/etc/nginx/sites-available/llm-gateway.conf"
+  log "Configuring Nginx reverse proxy"
+  sed "s/{{SERVER_NAME}}/${DOMAIN}/g" "${REPO_ROOT}/config/nginx/llm_gateway.conf" > "${nginx_conf}"
+  ln -sf "${nginx_conf}" /etc/nginx/sites-enabled/llm-gateway.conf
+  nginx -t
+  systemctl reload nginx
+}
+
+main() {
+  require_root
+  command -v openssl >/dev/null || { echo "openssl is required" >&2; exit 1; }
+  command -v nginx >/dev/null || { echo "nginx must be installed" >&2; exit 1; }
+
+  generate_certificates
+  configure_nginx
+
+  log "HTTPS setup complete"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add bash automation to harden Ubuntu, configure RSA HTTPS with nginx, and deploy the FastAPI service
- implement a FastAPI-based gateway that enforces regex-driven DLP before forwarding prompts to an upstream LLM
- include configuration templates and pytest coverage for the DLP engine

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9a540acbc832ebafbdd15f1a627ed